### PR TITLE
Add image build workflow

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,0 +1,66 @@
+name: Build and push OCI image to Docker Hub
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  check-current-branch:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.check_step.outputs.branch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get current branch
+        id: check_step
+        # 1. Get the list of branches ref where this tag exists
+        # 2. Remove 'origin/' from that result
+        # 3. Put that string in output
+        run: |
+          raw=$(git branch -r --contains ${{ github.ref }})
+          branch="$(echo ${raw//origin\//} | tr -d '\n')"
+          echo "{name}=branch" >> $GITHUB_OUTPUT
+          echo "Branches where this tag exists : $branch."
+
+  image:
+    runs-on: ubuntu-latest
+    needs: check-current-branch
+    if: contains(${{ needs.check.outputs.branch }}, 'main')`
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Get build args
+        id: build_args
+        run: |
+          echo "APP_COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "APP_VERSION=$(git describe --tags --always --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' 2> /dev/null | sed 's/^.//')" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: bsvb/cars-node
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_COMMIT=${{ steps.build_args.outputs.APP_COMMIT }}
+            APP_VERSION=${{ steps.build_args.outputs.APP_VERSION }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the building and pushing of an OCI image to Docker Hub when a new tag is pushed. The workflow includes steps for determining the branch associated with the tag, logging into Docker Hub, and building and pushing the image with metadata.

### New GitHub Actions workflow for OCI image automation:

* **Workflow name**: Added a new workflow named `Build and push OCI image to Docker Hub` in `.github/workflows/image.yaml`. The workflow triggers on pushes to tags matching the pattern `v*`.

* **Branch determination**: Introduced a `check-current-branch` job to identify the branch associated with the tag using Git commands. This ensures that the image is built only if the tag exists on the `main` branch.

* **Docker Hub integration**: Added steps to log into Docker Hub using credentials stored in GitHub Secrets (`DOCKER_USERNAME` and `DOCKER_PASSWORD`).

* **Image metadata and build**: Utilized `docker/metadata-action` to generate image tags and labels, and `docker/build-push-action` to build and push the image to Docker Hub. Build arguments include the short commit hash (`APP_COMMIT`) and the semantic version (`APP_VERSION`).